### PR TITLE
Rewrite class `Router`

### DIFF
--- a/admin/routes.php
+++ b/admin/routes.php
@@ -1,0 +1,201 @@
+<?php
+
+return [
+    'routes' => [
+        'admin.index' => [
+            'path'   => '/',
+            'action' => function () {
+                return \Formwork\Formwork::instance()->admin()->redirect('/dashboard/');
+            }
+        ],
+        'admin.login' => [
+            'path'    => '/login/',
+            'action'  => 'Formwork\\Admin\\Controllers\\AuthenticationController@login',
+            'methods' => ['GET', 'POST']
+        ],
+        'admin.logout' => [
+            'path'   => '/logout/',
+            'action' => 'Formwork\\Admin\\Controllers\\AuthenticationController@logout'
+        ],
+        'admin.backup.make' => [
+            'path'    => '/backup/make/',
+            'action'  => 'Formwork\\Admin\\Controllers\\BackupController@make',
+            'methods' => ['POST'],
+            'types'   => ['XHR']
+        ],
+        'admin.backup.download' => [
+            'path'    => '/backup/download/{backup}/',
+            'action'  => 'Formwork\\Admin\\Controllers\\BackupController@download',
+            'methods' => ['POST']
+        ],
+        'admin.cache.clear' => [
+            'path'    => '/cache/clear/',
+            'action'  => 'Formwork\\Admin\\Controllers\\CacheController@clear',
+            'methods' => ['POST'],
+            'types'   => ['XHR']
+        ],
+        'admin.dashboard' => [
+            'path'   => '/dashboard/',
+            'action' => '\Formwork\Admin\Controllers\DashboardController@index'
+        ],
+        'admin.options' => [
+            'path'   => '/options/',
+            'action' => '\Formwork\Admin\Controllers\OptionsController@index'
+        ],
+        'admin.options.system' => [
+            'path'    => '/options/system/',
+            'action'  => '\Formwork\Admin\Controllers\OptionsController@systemOptions',
+            'methods' => ['GET', 'POST']
+        ],
+        'admin.options.site' => [
+            'path'    => '/options/site/',
+            'action'  => '\Formwork\Admin\Controllers\OptionsController@siteOptions',
+            'methods' => ['GET', 'POST']
+        ],
+        'admin.options.updates' => [
+            'path'   => '/options/updates/',
+            'action' => '\Formwork\Admin\Controllers\OptionsController@updates'
+        ],
+        'admin.options.info' => [
+            'path'   => '/options/info/',
+            'action' => '\Formwork\Admin\Controllers\OptionsController@info'
+        ],
+        'admin.pages' => [
+            'path'   => '/pages/',
+            'action' => '\Formwork\Admin\Controllers\PagesController@index'
+        ],
+        'admin.pages.new' => [
+            'path'    => '/pages/new/',
+            'action'  => '\Formwork\Admin\Controllers\PagesController@create',
+            'methods' => ['POST']
+        ],
+        'admin.pages.edit' => [
+            'path'    => '/pages/{page}/edit/',
+            'action'  => '\Formwork\Admin\Controllers\PagesController@edit',
+            'methods' => ['GET', 'POST']
+        ],
+        'admin.pages.edit.lang' => [
+            'path'    => '/pages/{page}/edit/language/{language}/',
+            'action'  => '\Formwork\Admin\Controllers\PagesController@edit',
+            'methods' => ['GET', 'POST']
+        ],
+        'admin.pages.reorder' => [
+            'path'    => '/pages/reorder/',
+            'action'  => '\Formwork\Admin\Controllers\PagesController@reorder',
+            'methods' => ['POST'],
+            'types'   => ['XHR']
+        ],
+        'admin.pages.uploadfile' => [
+            'path'    => '/pages/{page}/file/upload/',
+            'action'  => '\Formwork\Admin\Controllers\PagesController@uploadFile',
+            'methods' => ['POST']
+        ],
+        'admin.pages.deletefile' => [
+            'path'    => '/pages/{page}/file/{filename}/delete/',
+            'action'  => '\Formwork\Admin\Controllers\PagesController@deleteFile',
+            'methods' => ['POST']
+        ],
+        'admin.pages.delete' => [
+            'path'    => '/pages/{page}/delete/',
+            'action'  => '\Formwork\Admin\Controllers\PagesController@delete',
+            'methods' => ['POST']
+        ],
+        'admin.pages.delete.lang' => [
+            'path'    => '/pages/{page}/delete/language/{language}/',
+            'action'  => '\Formwork\Admin\Controllers\PagesController@delete',
+            'methods' => ['POST']
+        ],
+        'admin.updates.check' => [
+            'path'    => '/updates/check/',
+            'action'  => '\Formwork\Admin\Controllers\UpdatesController@check',
+            'methods' => ['POST'],
+            'types'   => ['XHR']
+        ],
+        'admin.updates.update' => [
+            'path'    => '/updates/update/',
+            'action'  => '\Formwork\Admin\Controllers\UpdatesController@update',
+            'methods' => ['POST'],
+            'types'   => ['XHR']
+        ],
+        'admin.users' => [
+            'path'   => '/users/',
+            'action' => '\Formwork\Admin\Controllers\UsersController@index'
+        ],
+        'admin.users.new' => [
+            'path'    => '/users/new/',
+            'action'  => '\Formwork\Admin\Controllers\UsersController@create',
+            'methods' => ['POST']
+        ],
+        'admin.users.delete' => [
+            'path'    => '/users/{user}/delete/',
+            'action'  => '\Formwork\Admin\Controllers\UsersController@delete',
+            'methods' => ['POST']
+        ],
+        'admin.users.profile' => [
+            'path'    => '/users/{user}/profile/',
+            'action'  => '\Formwork\Admin\Controllers\UsersController@profile',
+            'methods' => ['GET', 'POST']
+        ]
+    ],
+    'filters' => [
+        'request.validate-size' => [
+            'action' => static function () {
+                // Validate HTTP request Content-Length according to post_max_size directive
+                if (\Formwork\Utils\HTTPRequest::contentLength() !== null) {
+                    $maxSize = \Formwork\Utils\FileSystem::shorthandToBytes(ini_get('post_max_size'));
+                    if (\Formwork\Utils\HTTPRequest::contentLength() > $maxSize && $maxSize > 0) {
+                        $admin = \Formwork\Formwork::instance()->admin();
+                        $admin->notify($admin->translate('admin.request.error.post-max-size'), 'error');
+                        return $admin->redirectToReferer();
+                    }
+                }
+            },
+            'methods' => ['POST']
+        ],
+        'request.validate-csrf' => [
+            'action' => static function () {
+                // Validate CSRF token
+                try {
+                    \Formwork\Admin\Security\CSRFToken::validate();
+                } catch (RuntimeException $e) {
+                    \Formwork\Admin\Security\CSRFToken::destroy();
+                    \Formwork\Utils\Session::remove('FORMWORK_USERNAME');
+                    $admin = \Formwork\Formwork::instance()->admin();
+                    $admin->notify($admin->translate('admin.login.suspicious-request-detected'), 'warning');
+                    if (\Formwork\Utils\HTTPRequest::isXHR()) {
+                        return \Formwork\Response\JSONResponse::error('Bad Request: the CSRF token is not valid', 400);
+                    }
+                    return $admin->redirect('/login/');
+                }
+            },
+            'methods' => ['POST'],
+            'types'   => ['HTTP', 'XHR']
+        ],
+        'admin.register' => [
+            'action' => static function () {
+                $admin = \Formwork\Formwork::instance()->admin();
+                // Register admin if no user exists
+                if ($admin->users()->isEmpty()) {
+                    if (!\Formwork\Utils\HTTPRequest::isLocalhost()) {
+                        return $admin->redirectToSite();
+                    }
+                    if ($admin->route() !== '/') {
+                        return $admin->redirectToPanel();
+                    }
+                    $controller = new \Formwork\Admin\Controllers\RegisterController();
+                    return $controller->register();
+                }
+            },
+        ],
+        'admin.redirect-to-login' => [
+            'action' => static function () {
+                $admin = \Formwork\Formwork::instance()->admin();
+                // Redirect to login if no user is logged
+                if (!$admin->isLoggedIn() && $admin->route() !== '/login/') {
+                    \Formwork\Utils\Session::set('FORMWORK_REDIRECT_TO', $admin->route());
+                    return $admin->redirect('/login/');
+                }
+            }
+        ]
+    ]
+];

--- a/formwork/defaults.php
+++ b/formwork/defaults.php
@@ -68,6 +68,12 @@ return [
     'parsers' => [
         'use_php_yaml' => 'parse'
     ],
+    'routes' => [
+        'files' => [
+            'admin'  => ADMIN_PATH . 'routes.php',
+            'system' => FORMWORK_PATH . 'routes.php'
+        ]
+    ],
     'schemes' => [
         'paths' => [
             'admin'  => ADMIN_PATH . 'schemes' . DS,

--- a/formwork/routes.php
+++ b/formwork/routes.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    'routes' => [
+        'index' => [
+            'path'   => '/',
+            'action' => 'Formwork\\Controllers\\PageController@load'
+        ],
+        'index.pagination' => [
+            'path'   => '/page/{paginationPage:num}/',
+            'action' => 'Formwork\\Controllers\\PageController@load'
+        ],
+        'tag.pagination' => [
+            'path'   => '/{page}/tag/{tagName:aln}/page/{paginationPage:num}/',
+            'action' => 'Formwork\\Controllers\\PageController@load'
+        ],
+        'tag' => [
+            'path'   => '/{page}/tag/{tagName:aln}/',
+            'action' => 'Formwork\\Controllers\\PageController@load'
+        ],
+        'page.pagination' => [
+            'path'   => '/{page}/page/{paginationPage:num}/',
+            'action' => 'Formwork\\Controllers\\PageController@load'
+        ],
+        'page' => [
+            'path'   => '/{page}/',
+            'action' => 'Formwork\\Controllers\\PageController@load'
+        ],
+    ]
+];

--- a/formwork/routes.php
+++ b/formwork/routes.php
@@ -25,6 +25,6 @@ return [
         'page' => [
             'path'   => '/{page}/',
             'action' => 'Formwork\\Controllers\\PageController@load'
-        ],
+        ]
     ]
 ];

--- a/formwork/src/Admin/Admin.php
+++ b/formwork/src/Admin/Admin.php
@@ -2,37 +2,23 @@
 
 namespace Formwork\Admin;
 
-use Formwork\Admin\Security\CSRFToken;
 use Formwork\Admin\Users\User;
 use Formwork\Admin\Users\Users;
 use Formwork\Assets;
 use Formwork\Formwork;
 use Formwork\Languages\LanguageCodes;
 use Formwork\Page;
-use Formwork\Response\JSONResponse;
 use Formwork\Response\RedirectResponse;
-use Formwork\Response\Response;
-use Formwork\Router\RouteParams;
-use Formwork\Router\Router;
-use Formwork\Translations\Translation;
 use Formwork\Utils\FileSystem;
 use Formwork\Utils\HTTPRequest;
 use Formwork\Utils\Notification;
 use Formwork\Utils\Session;
 use Formwork\Utils\Str;
 use Formwork\Utils\Uri;
-use RuntimeException;
 use Throwable;
 
 final class Admin
 {
-    /**
-     * Router instance
-     *
-     * @var Router
-     */
-    protected $router;
-
     /**
      * All the registered users
      *
@@ -59,7 +45,18 @@ final class Admin
      */
     public function __construct()
     {
-        $this->router = new Router(Uri::removeQuery($this->route()));
+    }
+
+    public function load()
+    {
+        $this->loadSchemes();
+
+        $this->users = Users::load();
+
+        $this->loadTranslations();
+        $this->loadErrorHandler();
+
+        $this->loadRoutes();
     }
 
     /**
@@ -86,29 +83,6 @@ final class Admin
     {
         $username = Session::get('FORMWORK_USERNAME');
         return $this->users->get($username);
-    }
-
-    /**
-     * Run the administration panel
-     */
-    public function run(): Response
-    {
-        $this->loadSchemes();
-
-        $this->users = Users::load();
-
-        $this->loadTranslations();
-        $this->loadErrorHandler();
-
-        $this->loadRoutes();
-
-        $response = $this->router->dispatch();
-
-        if (!$this->router->hasDispatched()) {
-            $response = $this->errors->notFound();
-        }
-
-        return $response;
     }
 
     /**
@@ -317,200 +291,9 @@ final class Admin
      */
     protected function loadRoutes(): void
     {
-        // Validate HTTP request Content-Length according to post_max_size directive
-        $this->router->before(function () {
-            if (HTTPRequest::contentLength() !== null) {
-                $maxSize = FileSystem::shorthandToBytes(ini_get('post_max_size'));
-                if (HTTPRequest::contentLength() > $maxSize && $maxSize > 0) {
-                    $this->notify($this->translate('admin.request.error.post-max-size'), 'error');
-                    return $this->redirectToReferer();
-                }
-            }
-        }, 'POST');
-
-        // Validate CSRF token
-        $this->router->before(function () {
-            try {
-                CSRFToken::validate();
-            } catch (RuntimeException $e) {
-                CSRFToken::destroy();
-                Session::remove('FORMWORK_USERNAME');
-                $this->notify($this->translate('admin.login.suspicious-request-detected'), 'warning');
-                if (HTTPRequest::isXHR()) {
-                    return JSONResponse::error('Bad Request: the CSRF token is not valid', 400);
-                }
-                return $this->redirect('/login/');
-            }
-        }, 'POST');
-
-        // Register admin if no user exists
-        $this->router->before(function () {
-            if ($this->users->isEmpty()) {
-                if (!HTTPRequest::isLocalhost()) {
-                    return $this->redirectToSite();
-                }
-                if ($this->router->request() !== '/') {
-                    return $this->redirectToPanel();
-                }
-                $controller = new Controllers\RegisterController();
-                return $controller->register();
-            }
-        });
-
-        // Redirect to login if no user is logged
-        $this->router->before(function () {
-            if (!$this->isLoggedIn() && $this->route() !== '/login/') {
-                Session::set('FORMWORK_REDIRECT_TO', $this->route());
-                return $this->redirect('/login/');
-            }
-        });
-
-        // Default route
-        $this->router->add(
-            '/',
-            function (RouteParams $params): Response {
-                return $this->redirect('/dashboard/');
-            }
-        );
-
-        // Authentication
-        $this->router->add(
-            '/login/',
-            Controllers\AuthenticationController::class . '@login',
-            ['GET', 'POST']
-        );
-        $this->router->add(
-            '/logout/',
-            Controllers\AuthenticationController::class . '@logout'
-        );
-
-        // Backup
-        $this->router->add(
-            '/backup/make/',
-            Controllers\BackupController::class . '@make',
-            'POST',
-            'XHR'
-        );
-        $this->router->add(
-            '/backup/download/{backup}/',
-            Controllers\BackupController::class . '@download',
-            'POST'
-        );
-
-        // Cache
-        $this->router->add(
-            '/cache/clear/',
-            Controllers\CacheController::class . '@clear',
-            'POST',
-            'XHR'
-        );
-
-        // Dashboard
-        $this->router->add(
-            '/dashboard/',
-            Controllers\DashboardController::class . '@index'
-        );
-
-        // Options
-        $this->router->add(
-            '/options/',
-            Controllers\OptionsController::class . '@index'
-        );
-        $this->router->add(
-            '/options/system/',
-            Controllers\OptionsController::class . '@systemOptions',
-            ['GET', 'POST']
-        );
-        $this->router->add(
-            '/options/site/',
-            Controllers\OptionsController::class . '@siteOptions',
-            ['GET', 'POST']
-        );
-        $this->router->add(
-            '/options/updates/',
-            Controllers\OptionsController::class . '@updates'
-        );
-        $this->router->add(
-            '/options/info/',
-            Controllers\OptionsController::class . '@info'
-        );
-
-        // Pages
-        $this->router->add(
-            '/pages/',
-            Controllers\PagesController::class . '@index'
-        );
-        $this->router->add(
-            '/pages/new/',
-            Controllers\PagesController::class . '@create',
-            'POST'
-        );
-        $this->router->add(
-            [
-                '/pages/{page}/edit/',
-                '/pages/{page}/edit/language/{language}/'
-            ],
-            Controllers\PagesController::class . '@edit',
-            ['GET', 'POST']
-        );
-        $this->router->add(
-            '/pages/reorder/',
-            Controllers\PagesController::class . '@reorder',
-            'POST',
-            'XHR'
-        );
-        $this->router->add(
-            '/pages/{page}/file/upload/',
-            Controllers\PagesController::class . '@uploadFile',
-            'POST'
-        );
-        $this->router->add(
-            '/pages/{page}/file/{filename}/delete/',
-            Controllers\PagesController::class . '@deleteFile',
-            'POST'
-        );
-        $this->router->add(
-            [
-                '/pages/{page}/delete/',
-                '/pages/{page}/delete/language/{language}/',
-            ],
-            Controllers\PagesController::class . '@delete',
-            'POST'
-        );
-
-        // Updates
-        $this->router->add(
-            '/updates/check/',
-            Controllers\UpdatesController::class . '@check',
-            'POST',
-            'XHR'
-        );
-        $this->router->add(
-            '/updates/update/',
-            Controllers\UpdatesController::class . '@update',
-            'POST',
-            'XHR'
-        );
-
-        // Users
-        $this->router->add(
-            '/users/',
-            Controllers\UsersController::class . '@index'
-        );
-        $this->router->add(
-            '/users/new/',
-            Controllers\UsersController::class . '@create',
-            'POST'
-        );
-        $this->router->add(
-            '/users/{user}/delete/',
-            Controllers\UsersController::class . '@delete',
-            'POST'
-        );
-        $this->router->add(
-            '/users/{user}/profile/',
-            Controllers\UsersController::class . '@profile',
-            ['GET', 'POST']
+        Formwork::instance()->router()->loadFromFile(
+            Formwork::instance()->config()->get('routes.files.admin'),
+            Str::wrap(Formwork::instance()->config()->get('admin.root'), '/')
         );
     }
 }

--- a/formwork/src/Formwork.php
+++ b/formwork/src/Formwork.php
@@ -104,6 +104,8 @@ final class Formwork
         $this->loadSchemes();
         $this->loadSite();
         $this->loadCache();
+        $this->loadRouter();
+        $this->loadAdmin();
         $this->loadRoutes();
     }
 
@@ -273,46 +275,24 @@ final class Formwork
         $this->cache = new SiteCache($this->config()->get('cache.path'), $this->config()->get('cache.time'));
     }
 
+    protected function loadRouter(): void
+    {
+        $this->router = new Router($this->request);
+    }
+
+    protected function loadAdmin(): void
+    {
+        if ($this->config->get('admin.enabled')) {
+            $this->admin = new Admin();
+            $this->admin->load();
+        }
+    }
+
     /**
      * Load routes
      */
     protected function loadRoutes(): void
     {
-        $this->router = new Router($this->request);
-
-        if ($this->config()->get('admin.enabled')) {
-            $this->loadAdminRoute();
-        }
-
-        $this->router->add(
-            [
-                '/',
-                '/page/{paginationPage:num}/',
-                '/{page}/tag/{tagName:aln}/page/{paginationPage:num}/',
-                '/{page}/tag/{tagName:aln}/',
-                '/{page}/page/{paginationPage:num}/',
-                '/{page}/'
-            ],
-            Controllers\PageController::class . '@load'
-        );
-    }
-
-    /**
-     * Load admin route
-     */
-    protected function loadAdminRoute(): void
-    {
-        $this->router->add(
-            [
-                '/' . $this->config()->get('admin.root') . '/',
-                '/' . $this->config()->get('admin.root') . '/{route}/'
-            ],
-            function () {
-                $this->admin = new Admin();
-                return $this->admin->run();
-            },
-            ['GET', 'POST'],
-            ['HTTP', 'XHR']
-        );
+        $this->router->loadFromFile($this->config()->get('routes.files.system'));
     }
 }

--- a/formwork/src/Router/CompiledRoute.php
+++ b/formwork/src/Router/CompiledRoute.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Formwork\Router;
+
+class CompiledRoute
+{
+    /**
+     * Route path
+     */
+    protected string $path;
+
+    /**
+     * Compiled route regex
+     */
+    protected string $regex;
+
+    /**
+     * Route params
+     */
+    protected array $params;
+
+    public function __construct(string $path, string $regex, array $params)
+    {
+        $this->path = $path;
+        $this->regex = $regex;
+        $this->params = $params;
+    }
+
+    /**
+     * Get route path
+     */
+    public function path(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * Get compiled route regex
+     */
+    public function regex(): string
+    {
+        return $this->regex;
+    }
+
+    /**
+     * Get route params
+     */
+    public function params(): array
+    {
+        return $this->params;
+    }
+}

--- a/formwork/src/Router/Exceptions/InvalidRouteException.php
+++ b/formwork/src/Router/Exceptions/InvalidRouteException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Formwork\Router\Exceptions;
+
+use LogicException;
+
+class InvalidRouteException extends LogicException
+{
+}

--- a/formwork/src/Router/Exceptions/RouteNotFoundException.php
+++ b/formwork/src/Router/Exceptions/RouteNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Formwork\Router\Exceptions;
+
+use RuntimeException;
+
+class RouteNotFoundException extends RuntimeException
+{
+}

--- a/formwork/src/Router/Route.php
+++ b/formwork/src/Router/Route.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Formwork\Router;
+
+class Route
+{
+    /**
+     * Default route methods
+     *
+     * @var array
+     */
+    protected const DEFAULT_METHODS = ['GET'];
+
+    /**
+     * Default route types
+     *
+     * @var array
+     */
+    protected const DEFAULT_TYPES = ['HTTP'];
+
+    /**
+     * Route name
+     */
+    protected string $name;
+
+    /**
+     * Route path
+     */
+    protected string $path;
+
+    /**
+     * Route action
+     *
+     * @var callable|string
+     */
+    protected $action;
+
+    /**
+     * Route methods
+     */
+    protected array $methods = self::DEFAULT_METHODS;
+
+    /**
+     * Route types
+     */
+    protected array $types = self::DEFAULT_TYPES;
+
+    /**
+     * Route prefix
+     */
+    protected string $prefix = '';
+
+    public function __construct(string $name, string $path)
+    {
+        $this->name = $name;
+        $this->path = $path;
+    }
+
+    /**
+     * Get route name
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get route path
+     */
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * Set route action
+     *
+     * @param callable|string $action
+     */
+    public function action($action): self
+    {
+        $this->action = $action;
+        return $this;
+    }
+
+    /**
+     * Get route action
+     *
+     * @return callable|string
+     */
+    public function getAction()
+    {
+        return $this->action;
+    }
+
+    /**
+     * Set route methods
+     */
+    public function methods(string ...$methods): self
+    {
+        $this->methods = $methods;
+        return $this;
+    }
+
+    /**
+     * Get route methods
+     */
+    public function getMethods(): array
+    {
+        return $this->methods;
+    }
+
+    /**
+     * Set route types
+     */
+    public function types(string ...$types): self
+    {
+        $this->types = $types;
+        return $this;
+    }
+
+    /**
+     * Get route types
+     */
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+
+    /**
+     * Set route prefix
+     */
+    public function prefix(string $prefix): self
+    {
+        $this->prefix = $prefix;
+        return $this;
+    }
+
+    /**
+     * Get route prefix
+     */
+    public function getPrefix(): string
+    {
+        return $this->prefix;
+    }
+}

--- a/formwork/src/Router/RouteCollection.php
+++ b/formwork/src/Router/RouteCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Formwork\Router;
+
+use Formwork\Data\AssociativeCollection;
+
+class RouteCollection extends AssociativeCollection
+{
+    /**
+     * Add route to the collection
+     */
+    public function add(Route $route): Route
+    {
+        return $this->items[$route->getName()] = $route;
+    }
+}

--- a/formwork/src/Router/RouteFilter.php
+++ b/formwork/src/Router/RouteFilter.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Formwork\Router;
+
+class RouteFilter
+{
+    /**
+     * Default filter methods
+     *
+     * @var array
+     */
+    protected const DEFAULT_METHODS = ['GET'];
+
+    /**
+     * Default filter types
+     *
+     * @var array
+     */
+    protected const DEFAULT_TYPES = ['HTTP'];
+
+    /**
+     * Filter name
+     */
+    protected string $name;
+
+    /**
+     * Filter action
+     *
+     * @var callable|string
+     */
+    protected $action;
+
+    /**
+     * Filter methods
+     */
+    protected array $methods = self::DEFAULT_METHODS;
+
+    /**
+     * Filter types
+     */
+    protected array $types = self::DEFAULT_TYPES;
+
+    /**
+     * Filter prefix
+     */
+    protected string $prefix = '';
+
+    /**
+     * @param callable|string $action
+     */
+    public function __construct(string $name, $action)
+    {
+        $this->name = $name;
+        $this->action = $action;
+    }
+
+    /**
+     * Get filter name
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get filter action
+     *
+     * @return callable|string
+     */
+    public function getAction()
+    {
+        return $this->action;
+    }
+
+    /**
+     * Set filter methods
+     */
+    public function methods(string ...$methods): self
+    {
+        $this->methods = $methods;
+        return $this;
+    }
+
+    /**
+     * Get filter methods
+     */
+    public function getMethods(): array
+    {
+        return $this->methods;
+    }
+
+    /**
+     * Set filter types
+     */
+    public function types(string ...$types): self
+    {
+        $this->types = $types;
+        return $this;
+    }
+
+    /**
+     * Get filter types
+     */
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+
+    /**
+     * Set filter prefix
+     */
+    public function prefix(string $prefix): self
+    {
+        $this->prefix = $prefix;
+        return $this;
+    }
+
+    /**
+     * Get filter prefix
+     */
+    public function getPrefix(): string
+    {
+        return $this->prefix;
+    }
+}

--- a/formwork/src/Router/RouteFilterCollection.php
+++ b/formwork/src/Router/RouteFilterCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Formwork\Router;
+
+use Formwork\Data\AssociativeCollection;
+
+class RouteFilterCollection extends AssociativeCollection
+{
+    /**
+     * Add filter to collection
+     */
+    public function add(RouteFilter $filter): RouteFilter
+    {
+        return $this->items[$filter->getName()] = $filter;
+    }
+}


### PR DESCRIPTION
This PR rewrites and enhances the `Router` class adding some new features:

1. No more messy `Router::add()` method. Now `Router::addRoute()` only takes the route name and path. Everything else is chained:
```php
$route = $router->addRoute('name', '/path/{param}/')
    ->action('Namespaced\\Controller\\ClassName@action')
    ->methods('GET', 'POST');
```
2. Optional route params:
```php
$route = $router->addRoute('name', '/path/{param}/{optionalParam?}/');
```
3. Now routes can be imported from external files:
```php
// /formwork/routes.php

return [
    'routes' => [
        'index' => [
            'path'   => '/',
            'action' => 'Formwork\\Controllers\\PageController@load'
        ],
        'index.pagination' => [
            'path'   => '/page/{paginationPage:num}/',
            'action' => 'Formwork\\Controllers\\PageController@load'
        ],
        'tag.pagination' => [
            'path'   => '/{page}/tag/{tagName:aln}/page/{paginationPage:num}/',
            'action' => 'Formwork\\Controllers\\PageController@load'
        ],
        'tag' => [
            'path'   => '/{page}/tag/{tagName:aln}/',
            'action' => 'Formwork\\Controllers\\PageController@load'
        ],
        'page.pagination' => [
            'path'   => '/{page}/page/{paginationPage:num}/',
            'action' => 'Formwork\\Controllers\\PageController@load'
        ],
        'page' => [
            'path'   => '/{page}/',
            'action' => 'Formwork\\Controllers\\PageController@load'
        ]
    ]
];

// /formwork/src/Formwork.php

// ...
    $this->router->loadFromFile($this->config()->get('routes.files.system'));
// ...
```